### PR TITLE
Fixed not found dotnet on macos

### DIFF
--- a/Unity/Assets/JCMG/Genesis/Scripts/Editor/EditorConstants.cs
+++ b/Unity/Assets/JCMG/Genesis/Scripts/Editor/EditorConstants.cs
@@ -62,7 +62,11 @@ namespace JCMG.Genesis.Editor
 		public const string GENESIS_FAILED_TO_UPDATE = "Genesis CLI failed to update.";
 
 		// Dotnet Core and Genesis Assemblies
+#if UNITY_EDITOR_OSX
+		public const string DOTNET_EXE = "/usr/local/share/dotnet/dotnet";
+#else // UNITY_EDITOR_OSX
 		public const string DOTNET_EXE = "dotnet";
+#endif // UNITY_EDITOR_OSX
 		public const string GENESIS_EXECUTABLE = "Genesis.CLI.dll";
 
 		// General file and path


### PR DESCRIPTION
# Description

I added a preprocessor directive for the Unity editor on macOS. For macOS I changed the dotnet path to `/usr/local/share/dotnet/dotnet`.


Fixes #25 

# How Has This Been Tested?

I tested the auto-import function in GenesisSettings.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
