### PR TITLE
Fixed auto import will fail if unity project path contains spaces

### DIFF
--- a/Unity/Assets/JCMG/Genesis/Scripts/Editor/CLI/GenesisCLIRunner.cs
+++ b/Unity/Assets/JCMG/Genesis/Scripts/Editor/CLI/GenesisCLIRunner.cs
@@ -257,7 +257,9 @@ namespace JCMG.Genesis.Editor
 		private static string GetConfigGenerationCLIArguments()
 		{
 			SB.Clear();
+			SB.Append(EditorConstants.QUOTE_STR);
 			SB.Append(GenesisPreferences.GetExecutablePath());
+			SB.Append(EditorConstants.QUOTE_STR);
 			SB.Append(EditorConstants.SPACE_STR);
 			SB.Append(CommandLineConstants.CONFIG_VERB_PARAM);
 			SB.Append(EditorConstants.SPACE_STR);


### PR DESCRIPTION
# Description

As already described the auto-import is failing if the unity project path contains spaces.

Fixes #27 

# How Has This Been Tested?

Created an environment with spaces in the path and followed the install instructions for Genesis.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
